### PR TITLE
Update TfsChangeset.cs

### DIFF
--- a/GitTfs/Core/TfsChangeset.cs
+++ b/GitTfs/Core/TfsChangeset.cs
@@ -156,7 +156,14 @@ namespace Sep.Git.Tfs.Core
 
         private LogEntry MakeNewLogEntry(IChangeset changesetToLog, IGitTfsRemote remote = null)
         {
-            var identity = _tfs.GetIdentity(changesetToLog.Committer);
+            IIdentity identity = null;
+            try
+            {
+                identity = _tfs.GetIdentity(changesetToLog.Committer);
+            }
+            catch
+            {
+            }
             var name = changesetToLog.Committer;
             var email = changesetToLog.Committer;
             if (_authors != null && _authors.Authors.ContainsKey(changesetToLog.Committer))


### PR DESCRIPTION
Prevent failure while cloning when a TFS contributor's Active Directory account has been deleted.
Just wrap GetIdentity call with a try/catch.
